### PR TITLE
Added report creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,60 +1,60 @@
 {
-	"name": "powerbi-client-react",
-	"version": "1.3.1",
-	"description": "React wrapper for powerbi-client library",
-	"main": "dist/powerbi-client-react.js",
-	"types": "dist/powerbi-client-react.d.ts",
-	"files": [
-		"dist"
-	],
-	"scripts": {
-		"prebuild": "npm run lint",
-		"build": "webpack --mode=production --config config/src/webpack.config.js",
-		"build:dev": "webpack --mode=development --config config/src/webpack.config.js",
-		"pretest": "webpack --config config/test/webpack.config.js",
-		"test": "karma start config/test/karma.conf.js",
-		"install:demo": "cd demo && npm install",
-		"demo": "cd demo && npm run demo",
-		"lint": "eslint --fix src/**/*.{ts,tsx}"
-	},
-	"keywords": [
-		"microsoft",
-		"powerbi",
-		"embedded",
-		"react"
-	],
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/microsoft/powerbi-client-react.git"
-	},
-	"license": "MIT",
-	"dependencies": {
-		"lodash.isequal": "^4.5.0",
-		"powerbi-client": "^2.16.5"
-	},
-	"peerDependencies": {
-		"react": ">= 16"
-	},
-	"devDependencies": {
-		"@types/jasmine": "^3.5.10",
-		"@types/lodash.isequal": "^4.5.5",
-		"@types/node": "^14.0.5",
-		"@types/react": "^16.9.35",
-		"@types/react-dom": "^16.9.8",
-		"@typescript-eslint/eslint-plugin": "^3.1.0",
-		"@typescript-eslint/parser": "^3.0.2",
-		"eslint": "^7.4.0",
-		"eslint-plugin-react": "^7.20.0",
-		"jasmine-core": "^3.5.0",
-		"karma": "^5.0.9",
-		"karma-jasmine": "^3.1.1",
-		"karma-phantomjs-launcher": "^1.0.4",
-		"react": "^16.13.1",
-		"react-app-polyfill": "^1.0.6",
-		"react-dom": "^16.13.1",
-		"ts-loader": "^7.0.5",
-		"typescript": "^3.9.6",
-		"webpack": "^4.43.0",
-		"webpack-cli": "^3.3.11"
-	}
+  "name": "powerbi-client-react",
+  "version": "1.3.3",
+  "description": "React wrapper for powerbi-client library",
+  "main": "dist/powerbi-client-react.js",
+  "types": "dist/powerbi-client-react.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prebuild": "npm run lint",
+    "build": "webpack --mode=production --config config/src/webpack.config.js",
+    "build:dev": "webpack --mode=development --config config/src/webpack.config.js",
+    "pretest": "webpack --config config/test/webpack.config.js",
+    "test": "karma start config/test/karma.conf.js",
+    "install:demo": "cd demo && npm install",
+    "demo": "cd demo && npm run demo",
+    "lint": "eslint --fix src/**/*.{ts,tsx}"
+  },
+  "keywords": [
+    "microsoft",
+    "powerbi",
+    "embedded",
+    "react"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/powerbi-client-react.git"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "lodash.isequal": "^4.5.0",
+    "powerbi-client": "^2.16.5"
+  },
+  "peerDependencies": {
+    "react": ">= 16"
+  },
+  "devDependencies": {
+    "@types/jasmine": "^3.5.10",
+    "@types/lodash.isequal": "^4.5.5",
+    "@types/node": "^14.0.5",
+    "@types/react": "^16.9.35",
+    "@types/react-dom": "^16.9.8",
+    "@typescript-eslint/eslint-plugin": "^3.1.0",
+    "@typescript-eslint/parser": "^3.0.2",
+    "eslint": "^7.4.0",
+    "eslint-plugin-react": "^7.20.0",
+    "jasmine-core": "^3.5.0",
+    "karma": "^5.0.9",
+    "karma-jasmine": "^3.1.1",
+    "karma-phantomjs-launcher": "^1.0.4",
+    "react": "^16.13.1",
+    "react-app-polyfill": "^1.0.6",
+    "react-dom": "^16.13.1",
+    "ts-loader": "^7.0.5",
+    "typescript": "^3.9.6",
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.11"
+  }
 }

--- a/src/PowerBIEmbed.tsx
+++ b/src/PowerBIEmbed.tsx
@@ -306,6 +306,7 @@ export class PowerBIEmbed extends React.Component<EmbedProps> {
 		// Append entity specific events
 		switch (entityType) {
 			case EmbedType.Report:
+			case EmbedType.Create:
 				allowedEvents = [...allowedEvents, ...Report.allowedEvents]
 				break;
 			case EmbedType.Dashboard:

--- a/test/PowerBIEmbed.spec.tsx
+++ b/test/PowerBIEmbed.spec.tsx
@@ -5,11 +5,26 @@ import 'react-app-polyfill/ie11';	// For PhantomJS compatibility
 import 'react-app-polyfill/stable';	// For PhantomJS compatibility
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { act, isElement } from 'react-dom/test-utils';
-import { Report, Dashboard, service, factories, IEmbedSettings } from 'powerbi-client';
+import {
+  Dashboard,
+  factories,
+  IEmbedSettings,
+  Report,
+  service,
+} from 'powerbi-client';
+import {
+  FilterType,
+  IBasicFilter,
+} from 'powerbi-models';
+import {
+  act,
+  isElement,
+} from 'react-dom/test-utils';
 import { PowerBIEmbed } from '../src/PowerBIEmbed';
-import { mockPowerBIService, mockedMethods } from "./mockService";
-import { IBasicFilter, FilterType } from 'powerbi-models';
+import {
+  mockedMethods,
+  mockPowerBIService,
+} from './mockService';
 
 // Use this function to render powerbi entity with only config
 function renderReport(container: HTMLDivElement, config) {
@@ -134,6 +149,24 @@ describe('tests of PowerBIEmbed', function () {
 			// Assert
 			expect(testReport).not.toBe(undefined);
 			expect(testReport instanceof Dashboard).toBe(true);
+		});
+
+		it('gets the created report object', () => {
+
+			// Arrange
+			let testReport = undefined;
+
+			// Act
+			testReport = renderReport(container, {
+				type: 'create',
+				datasetId: '1234',
+				accessToken: 'token',
+				embedUrl: 'https://embed'
+			});
+
+			// Assert
+			expect(testReport).not.toBe(undefined);
+			expect(testReport.constructor.name).toBe('Create'); // Couldn't figure out how to import Create, so hack it is!
 		});
 	});
 
@@ -312,7 +345,7 @@ describe('tests of PowerBIEmbed', function () {
 
 	describe('test powerbi updating report filters', () => {
 		it('applies the updated filter', () => {
-			
+
 			// Arrange
 			let testReport: Report = undefined;
 			const config = {
@@ -343,7 +376,7 @@ describe('tests of PowerBIEmbed', function () {
 		});
 
 		it('does not apply filter if same filter is provided in the new config', () => {
-			
+
 			// Arrange
 			let testReport: Report = undefined;
 			const oldConfig = {
@@ -363,7 +396,7 @@ describe('tests of PowerBIEmbed', function () {
 
 			spyOn(testReport, 'setFilters').and.callThrough();
 			spyOn(testReport, 'removeFilters').and.callThrough();
-			
+
 			// Act
 			act(() => {
 				ReactDOM.render(
@@ -400,7 +433,7 @@ describe('tests of PowerBIEmbed', function () {
 			};
 
 			testReport = renderReport(container, oldConfig);
-			
+
 			spyOn(testReport, 'removeFilters').and.callThrough();
 
 			// Act
@@ -432,7 +465,7 @@ describe('tests of PowerBIEmbed', function () {
 				accessToken: 'fakeToken',
 				pageName: 'fakePage',
 			};
-			
+
 			testReport = renderReport(container, { type: 'report' });
 			spyOn(testReport, 'setPage').and.callThrough();
 
@@ -446,7 +479,7 @@ describe('tests of PowerBIEmbed', function () {
 						}}
 					/>, container);
 			});
-			
+
 			// Assert
 			expect(testReport.setPage).toHaveBeenCalledTimes(1);
 			expect(testReport.setPage).toHaveBeenCalledWith(config.pageName);
@@ -465,7 +498,7 @@ describe('tests of PowerBIEmbed', function () {
 
 			testReport = renderReport(container, { type: 'report' });
 			spyOn(testReport, 'setPage').and.callThrough();
-			
+
 			// Act
 			act(() => {
 				ReactDOM.render(
@@ -500,7 +533,7 @@ describe('tests of PowerBIEmbed', function () {
 			testReport = renderReport(container, oldConfig);
 
 			spyOn(testReport, 'setPage').and.callThrough();
-			
+
 			// Act
 			act(() => {
 				ReactDOM.render(

--- a/test/mockService.ts
+++ b/test/mockService.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-const mockedMethods = ['init', 'embed', 'bootstrap', 'load', 'get', 'reset', 'preload'];
+const mockedMethods = ['init', 'embed', 'bootstrap', 'load', 'get', 'reset', 'preload', 'createReport'];
 
 const mockPowerBIService = jasmine.createSpyObj('mockService', mockedMethods);
 


### PR DESCRIPTION
Added ability to set `type` to `create` in order to create a new report.

Known issues:
- Does not work if you do not include `embedUrl` and `accessToken` properties (not sure if this matters, since I barely know how to use this component in the first place)
- Hacky test for determining whether the resulting object is a `Create`.  I could not figure out how to import the class, so I just used `report.constructor.name === 'Create'`.

Willing to make edits.