### PR TITLE
Clarified options for tokenType enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import { PowerBIEmbed } from 'powerbi-client-react';
 		id: '<Report Id>',
 		embedUrl: '<Embed Url>',
 		accessToken: '<Access Token>',
-		tokenType: models.TokenType.Embed,
+		tokenType: models.TokenType.Embed, // Supported tokenTypes, Aad for user owns data and Embed for app owns data
 		settings: {
 			panes: {
 				filters: {


### PR DESCRIPTION
Added a clarifying comment about the possible values of the tokenType enum and when to use them in the same way as the comment for type does.
This has caused confusion with users previously so hopefully this reduces that in future